### PR TITLE
Validate that user has access to budget before performing CRUD operations on items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change log
+
+## [Unreleased]
+
+### Security
+
+- Validating user has access to the budget when they are doing any operations on items
+
+## [0.1.0] - 2023-03-08
+
+### Added
+
+- CRUD endpoints for budget
+- CRUD endpoints for managing items on a budget
+- JWT authorization with [Auth0](https://auth0.com) as authority
+- Tracing support throughout application
+- Customize port to run at from environment variable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "uuid",
 ]
 
@@ -1786,6 +1787,29 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
+dependencies = [
+ "lazy_static",
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
+dependencies = [
+ "lazy_static",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tower-http = { version = "0.3.5", features = ["trace"] }
 
 [dev-dependencies]
 derive-new = "0.5.9"
+tracing-test = "0.2.4"
 
 [profile.dev.package.sqlx-macros]
 opt-level = 3

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -13,6 +13,45 @@
     },
     "query": "DELETE FROM budget WHERE user_id = $1 AND id = $2"
   },
+  "07d22a4da37f9d751209eef662fb9e526b59886f948339862899904c140b7cc5": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "user_id",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "title",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 3,
+          "type_info": "Timestamp"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text"
+        ]
+      }
+    },
+    "query": "SELECT * FROM budget WHERE id = $1 AND user_id = $2"
+  },
   "0a1585a34618152585e4cf39a6b13e0f1f124192e83314a48aa2b6fd7d4f60ba": {
     "describe": {
       "columns": [
@@ -57,6 +96,63 @@
       }
     },
     "query": "SELECT b.*,\nCASE\n    WHEN count(i) = 0 THEN '{}'\n    ELSE\n        array_agg(\n            (i.id, i.budget_id, i.category, i.name, i.amount, i.created_at, i.modified_at)\n        )\n    END as \"items!: Vec<model::Item>\"\nFROM budget AS b\nLEFT JOIN item AS i ON b.id = i.budget_id\nWHERE b.id = $1 AND b.user_id = $2\nGROUP BY b.id\n"
+  },
+  "0fa3ff739e8788b80726a764920c8348af368e494c5e9334ddaa4f8bf4b6d6ed": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "budget_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "category",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "name",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "amount",
+          "ordinal": 4,
+          "type_info": "Int4"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 5,
+          "type_info": "Timestamp"
+        },
+        {
+          "name": "modified_at",
+          "ordinal": 6,
+          "type_info": "Timestamp"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "SELECT * FROM item WHERE id = $1 AND budget_id = $2 "
   },
   "196f16b63c0cc5993e8b5af0cbee312abccdf7efb706863585ff2aff9dfe402f": {
     "describe": {
@@ -176,61 +272,5 @@
       }
     },
     "query": "INSERT INTO budget (user_id, title) VALUES ($1, $2) RETURNING id"
-  },
-  "f9d244aac1e9a1bd77c7fad79f4bc1a84c641793058aecc121e3fe7d5df27b6f": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "budget_id",
-          "ordinal": 1,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "category",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "name",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "amount",
-          "ordinal": 4,
-          "type_info": "Int4"
-        },
-        {
-          "name": "created_at",
-          "ordinal": 5,
-          "type_info": "Timestamp"
-        },
-        {
-          "name": "modified_at",
-          "ordinal": 6,
-          "type_info": "Timestamp"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      }
-    },
-    "query": "SELECT * FROM item WHERE id = $1"
   }
 }

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -139,7 +139,10 @@ mod endpoints {
             "User '{}' add item to budget {budget_id}. Payload: {payload:?}",
             claims.user_id()
         );
-        match repository.add_item_to_budget(budget_id, payload).await {
+        match repository
+            .add_item_to_budget(claims.user_id(), budget_id, payload)
+            .await
+        {
             Ok(id) => Ok(id.to_string()),
             Err(_) => Err(StatusCode::BAD_REQUEST),
         }
@@ -157,9 +160,11 @@ mod endpoints {
             "User '{}' update item {item_id} on budget {budget_id}. Payload: {payload:?}",
             claims.user_id()
         );
-        // TODO: Validate user has access to budget (necessary for more than just this endpoint)
 
-        match repository.update_item(item_id, payload).await {
+        match repository
+            .update_item(claims.user_id(), budget_id, item_id, payload)
+            .await
+        {
             Ok(_) => StatusCode::ACCEPTED,
             Err(_) => StatusCode::BAD_REQUEST,
         }


### PR DESCRIPTION
- Updates all item related CRUD operations to ensure the calling user actually has access to the budget that is being edited. These have been implemented directly through the SQL queries.
- Added `tracing_test` to log events during testing.
- Introduced `CHANGELOG.md` to keep a human readable log of the changes. Inspired by [keepachangelog.com](keeepachangelog.com).