### PR TITLE
feat: Only load jwks keys once during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Validating user has access to the budget when they are doing any operations on items
 
+### Changed
+
+- Only fetch JWKs once on application startup
+- Refactored state into a global container to match axum's model for how to better share different services across handles
+
 ## [0.1.0] - 2023-03-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "chrono",
  "derive-getters",
  "derive-new",
+ "duplicate",
  "jsonwebtoken",
  "reqwest",
  "serde",
@@ -363,6 +364,16 @@ name = "dotenvy"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
+
+[[package]]
+name = "duplicate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de78e66ac9061e030587b2a2e75cc88f22304913c907b11307bca737141230cb"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+]
 
 [[package]]
 name = "either"
@@ -1026,6 +1037,30 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ derive-getters = "0.2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tower-http = { version = "0.3.5", features = ["trace"] }
+duplicate = "1.0.0"
 
 [dev-dependencies]
 derive-new = "0.5.9"

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,6 +1,7 @@
 use std::{error::Error, sync::Arc};
 
 use axum::extract::FromRef;
+use derive_getters::Getters;
 use duplicate::duplicate_item;
 use sqlx::PgPool;
 use tracing::trace;
@@ -12,7 +13,7 @@ use crate::{
 
 /// Represents the global app state for Axum.
 /// Can also be considered as the DoI container for the application.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Getters)]
 pub struct AppState {
     jwks_repository: Arc<JwkRepository>,
     budget_repository: Arc<BudgetRepository>,

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,0 +1,51 @@
+use std::{error::Error, sync::Arc};
+
+use axum::extract::FromRef;
+use duplicate::duplicate_item;
+use sqlx::PgPool;
+use tracing::trace;
+
+use crate::{
+    auth::{config::AuthConfig, jwk::JwkRepository},
+    budget::{item_repository::ItemRepository, repository::BudgetRepository},
+};
+
+/// Represents the global app state for Axum.
+/// Can also be considered as the DoI container for the application.
+#[derive(Debug, Clone)]
+pub struct AppState {
+    jwks_repository: Arc<JwkRepository>,
+    budget_repository: Arc<BudgetRepository>,
+    item_repository: Arc<ItemRepository>,
+}
+
+impl AppState {
+    pub async fn initialize() -> Result<Self, Box<dyn Error>> {
+        trace!("Initializing application services");
+        let url = std::env::var("DATABASE_URL").expect(
+            "Missing environment variable 'DATABASE_URL' provided with a connection string",
+        );
+        let pool = Arc::new(PgPool::connect(&url).await.unwrap());
+
+        let auth_config = AuthConfig::from_env();
+        let jwks_repository = Arc::new(JwkRepository::new(auth_config).await?);
+
+        Ok(Self {
+            jwks_repository,
+            budget_repository: Arc::new(BudgetRepository::new(pool.clone())),
+            item_repository: Arc::new(ItemRepository::new(pool.clone())),
+        })
+    }
+}
+
+#[duplicate_item(
+    service_type         field;
+    [ BudgetRepository ] [ budget_repository ];
+    [ ItemRepository ]   [ item_repository ];
+    [ JwkRepository ]    [ jwks_repository ];
+)]
+impl FromRef<AppState> for Arc<service_type> {
+    fn from_ref(app_state: &AppState) -> Self {
+        app_state.field.clone()
+    }
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,5 +1,5 @@
 pub mod config;
-mod jwk;
+pub mod jwk;
 
 use std::collections::HashSet;
 

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -4,7 +4,7 @@ use jsonwebtoken::{Algorithm, Validation};
 pub(crate) static ISSUER: &str = "https://oliverflecke.eu.auth0.com/";
 pub(crate) static AUDIENCE: &str = "https://finance.oliverflecke.me/";
 
-#[derive(Debug, Getters)]
+#[derive(Debug, Getters, Clone)]
 pub struct AuthConfig {
     issuer: String,
     audience: String,

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -10,6 +10,15 @@ pub struct AuthConfig {
     audience: String,
 }
 
+impl AuthConfig {
+    pub fn from_env() -> Self {
+        Self {
+            issuer: std::env::var("ISSUER").expect("variable 'ISSUER' to be set"),
+            audience: std::env::var("AUDIENCE").expect("variable 'AUDIENCE' to be set"),
+        }
+    }
+}
+
 impl Default for AuthConfig {
     fn default() -> Self {
         Self {

--- a/src/auth/jwk.rs
+++ b/src/auth/jwk.rs
@@ -46,7 +46,7 @@ impl From<Jwk> for DecodingKey {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct JwkRepository {
     auth_config: AuthConfig,
     keys: Vec<Jwk>,

--- a/src/budget/item_repository.rs
+++ b/src/budget/item_repository.rs
@@ -15,6 +15,7 @@ pub enum ItemRepositoryError {
 
 /// Repository to access items.
 /// Abstracts away the DB interations for items.
+#[derive(Debug)]
 pub struct ItemRepository {
     db_pool: Arc<PgPool>,
 }

--- a/src/budget/repository.rs
+++ b/src/budget/repository.rs
@@ -8,6 +8,7 @@ use super::model;
 
 /// Repository to access budgets.
 /// Used to abstract away the DB interation for the rest of the application.
+#[derive(Debug)]
 pub struct BudgetRepository {
     db_pool: Arc<PgPool>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod app_state;
 pub mod auth;
 pub mod budget;


### PR DESCRIPTION
Implements a repository for JWKs. The current behaivor fetches the keys on every request — this will instead only fetch the keys one during startup. 

The structure of the app has also been refactored to use a global `AppState`, which acts as a container for all services used throughout. This seems like the proper way to do it in [axum](https://docs.rs/axum), with `FromRef` used to extract substates for the different handlers.

## Changelog

- feat: Loading `AuthConfig` from environment
- feat: Repository for JWKs
- feat: Introduced a global `AppState` to act like a DI container
- feat: Using the new `AppState` to extract and use the `JwkRepository` when validating claims
