### PR TITLE
test: Add framework for integration test through http endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,14 +23,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.64"
+name = "anyhow"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
+name = "async-trait"
+version = "0.1.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -50,9 +56,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.6"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -78,16 +84,15 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -102,14 +107,14 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bcef27b56d5cad8912d735d5ed1286f073f7bcb88cc31b38a15b514fcf8600"
+checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -143,11 +148,13 @@ dependencies = [
 name = "budget-api"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "chrono",
  "derive-getters",
  "derive-new",
  "duplicate",
+ "hyper",
  "jsonwebtoken",
  "reqwest",
  "serde",
@@ -299,7 +306,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -316,7 +323,7 @@ checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -327,7 +334,7 @@ checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -338,7 +345,7 @@ checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -502,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
 dependencies = [
  "bytes",
  "fnv",
@@ -606,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -646,9 +653,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1030,7 +1037,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1060,7 +1067,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -1077,18 +1084,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1293,7 +1300,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1506,7 +1513,7 @@ dependencies = [
  "sha2",
  "sqlx-core",
  "sqlx-rt",
- "syn",
+ "syn 1.0.107",
  "url",
 ]
 
@@ -1549,6 +1556,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,7 +1598,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1674,7 +1692,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1743,7 +1761,6 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1782,7 +1799,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1857,7 +1874,7 @@ checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
 dependencies = [
  "lazy_static",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1994,7 +2011,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -2028,7 +2045,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 db_test = []
 
 [dependencies]
-axum = { version = "0.6.1", features = ["headers", "macros"] }
+axum = { version = "0.6.20", features = ["headers", "macros", "http2"] }
+hyper = "0.14.27"
 serde = { version = "1.0.152", features = ["derive"] }
 sqlx = { version = "0.6.2", default-features = false, features = [
   'runtime-tokio-rustls',
@@ -32,6 +33,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tower-http = { version = "0.3.5", features = ["trace"] }
 duplicate = "1.0.0"
+anyhow = "1.0.75"
 
 [dev-dependencies]
 derive-new = "0.5.9"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.68.0 as build
+FROM rust:1.72.0 as build
 
 RUN USER=root cargo new --bin app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The API currently have the following features:
 
 ## Build
 
-Application is tested with Rust v1.64, but newer will likely work.
+Application is tested with Rust v1.72, but newer versions will likely work.
 Start the application with:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ The API currently have the following features:
 - [x] Update items' **name**, **category**, or **amount**
 - [x] Delete items from a budget
 - [x] Authorize as a user
-  - Note: Currently this is a very simple "authorization" that simply allow you to specify your user id. There is NO actual security in this
   - [x] JWT authorization
 
 ## Build
@@ -35,6 +34,8 @@ Test can be run with the stardard `cargo test`.
 Note that not all tests are activated by default. As the database layer needs an active database to work (sqlx does not seem to support offline mode yet for tests), these are disabled by default. To run them, you need to have a running database (see below). All tests can then be run with `cargo test --features db_test`.
 
 ## Database
+
+The easiest way to build/test/run the application is to set the environment variable `SQLX_OFFLINE=true`, which will use the precompiled queries to the database to compile.
 
 It requires a Postgres database to run against and persist data.
 See `scripts/start_db.sh` to start Postgres in a Docker container.

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,15 +1,14 @@
-use std::{error::Error, sync::Arc};
-
-use axum::extract::FromRef;
-use derive_getters::Getters;
-use duplicate::duplicate_item;
-use sqlx::PgPool;
-use tracing::trace;
-
 use crate::{
     auth::{config::AuthConfig, jwk::JwkRepository},
     budget::{item_repository::ItemRepository, repository::BudgetRepository},
 };
+use anyhow::Result;
+use axum::extract::FromRef;
+use derive_getters::Getters;
+use duplicate::duplicate_item;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tracing::trace;
 
 /// Represents the global app state for Axum.
 /// Can also be considered as the DoI container for the application.
@@ -21,7 +20,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub async fn initialize() -> Result<Self, Box<dyn Error>> {
+    pub async fn initialize() -> Result<Self> {
         trace!("Initializing application services");
         let url = std::env::var("DATABASE_URL").expect(
             "Missing environment variable 'DATABASE_URL' provided with a connection string",

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -10,7 +10,7 @@ use axum::{
 
 use crate::app_state::AppState;
 
-pub fn create_budget_router(state: AppState) -> Router {
+pub fn create_router(state: AppState) -> Router {
     Router::new()
         .route("/", get(endpoints::get_all_budgets))
         .route("/", post(endpoints::create_budget))

--- a/src/health_check.rs
+++ b/src/health_check.rs
@@ -1,0 +1,9 @@
+use axum::{http::StatusCode, routing::get, Router};
+
+pub fn create_router() -> Router {
+    Router::new().route("/", get(is_alive))
+}
+
+async fn is_alive() -> StatusCode {
+    StatusCode::OK
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,57 @@
+use crate::{app_state::AppState, budget::create_budget_router};
+use axum::{
+    http::{StatusCode, Uri},
+    Router,
+};
+use std::{error::Error, net::SocketAddr};
+use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};
+use tracing::{info, trace, warn, Level};
+use tracing_subscriber::{self, layer::SubscriberExt, util::SubscriberInitExt};
+
 pub mod app_state;
 pub mod auth;
 pub mod budget;
+
+pub async fn run_server(host: &SocketAddr) -> Result<(), Box<dyn Error>> {
+    // Initialize services
+    setup_tracing();
+    trace!("Initialize services");
+
+    let app_state = AppState::initialize().await?;
+
+    // Build app
+    trace!("Building app");
+    let app = Router::new()
+        .nest("/budget", create_budget_router(app_state))
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+                .on_request(DefaultOnRequest::new().level(Level::INFO))
+                .on_response(DefaultOnResponse::new().level(Level::INFO)),
+        )
+        .fallback(not_found);
+
+    // Run app
+    info!("Server running at {host}");
+    axum::Server::bind(&host)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+
+    Ok(())
+}
+
+fn setup_tracing() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "budget_api=debug,hyper=info,tower_http=info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer().compact())
+        .init();
+}
+
+async fn not_found(uri: Uri) -> (StatusCode, String) {
+    warn!("Path not found {uri}");
+    (StatusCode::NOT_FOUND, format!("No route for '{uri}'"))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub mod budget;
 
 pub async fn run_server(host: &SocketAddr) -> Result<(), Box<dyn Error>> {
     // Initialize services
-    setup_tracing();
+    setup_tracing()?;
     trace!("Initialize services");
 
     let app_state = AppState::initialize().await?;
@@ -41,14 +41,18 @@ pub async fn run_server(host: &SocketAddr) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn setup_tracing() {
+fn setup_tracing() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::registry()
         .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "budget_api=debug,hyper=info,tower_http=info".into()),
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("budget_api=debug".parse()?)
+                .add_directive("hyper=info".parse()?)
+                .add_directive("tower_http=info".parse()?),
         )
         .with(tracing_subscriber::fmt::layer().compact())
         .init();
+
+    Ok(())
 }
 
 async fn not_found(uri: Uri) -> (StatusCode, String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,15 @@
-use std::{error::Error, net::SocketAddr};
+use std::net::TcpListener;
 
-use budget_api::run_server;
+use budget_api::App;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> anyhow::Result<()> {
     let port = std::env::var("PORT")
         .map(|p| p.parse::<usize>().expect("PORT is not a valid integer"))
         .unwrap_or(4000);
-    let host: SocketAddr = format!("0.0.0.0:{port}").parse().unwrap();
+    let listener = TcpListener::bind(format!("0.0.0.0:{port}"))?;
 
-    run_server(&host).await
+    App::create().await?.serve(listener).await?;
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,61 +1,13 @@
-use std::error::Error;
+use std::{error::Error, net::SocketAddr};
 
-use axum::{
-    http::{StatusCode, Uri},
-    Router,
-};
-use budget_api::{app_state::AppState, budget::create_budget_router};
-
-use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};
-use tracing::{info, trace, warn, Level};
-use tracing_subscriber::{self, layer::SubscriberExt, util::SubscriberInitExt};
+use budget_api::run_server;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // Initialize services
-    setup_tracing();
-    trace!("Initialize services");
-
     let port = std::env::var("PORT")
         .map(|p| p.parse::<usize>().expect("PORT is not a valid integer"))
         .unwrap_or(4000);
-    let host = format!("0.0.0.0:{port}").parse().unwrap();
+    let host: SocketAddr = format!("0.0.0.0:{port}").parse().unwrap();
 
-    let app_state = AppState::initialize().await?;
-
-    // Build app
-    trace!("Building app");
-    let app = Router::new()
-        .nest("/budget", create_budget_router(app_state))
-        .layer(
-            TraceLayer::new_for_http()
-                .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
-                .on_request(DefaultOnRequest::new().level(Level::INFO))
-                .on_response(DefaultOnResponse::new().level(Level::INFO)),
-        )
-        .fallback(not_found);
-
-    // Run app
-    info!("Server running at {host}");
-    axum::Server::bind(&host)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
-
-    Ok(())
-}
-
-fn setup_tracing() {
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "budget_api=debug,hyper=info,tower_http=info".into()),
-        )
-        .with(tracing_subscriber::fmt::layer().compact())
-        .init();
-}
-
-async fn not_found(uri: Uri) -> (StatusCode, String) {
-    warn!("Path not found {uri}");
-    (StatusCode::NOT_FOUND, format!("No route for '{uri}'"))
+    run_server(&host).await
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use budget_api::App;
+use budget_api::{auth::config::AuthConfig, App};
 use derive_getters::Getters;
 use std::net::TcpListener;
 
@@ -12,6 +12,10 @@ pub async fn spawn_app() -> anyhow::Result<TestApp> {
     let test_app = TestApp {
         address: format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port()),
     };
+
+    let auth_config = AuthConfig::default();
+    std::env::set_var("ISSUER", auth_config.issuer());
+    std::env::set_var("AUDIENCE", auth_config.audience());
 
     let server = App::create()
         .await

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,23 @@
+use budget_api::App;
+use derive_getters::Getters;
+use std::net::TcpListener;
+
+#[derive(Debug, Getters)]
+pub struct TestApp {
+    address: String,
+}
+
+pub async fn spawn_app() -> anyhow::Result<TestApp> {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind address");
+    let test_app = TestApp {
+        address: format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port()),
+    };
+
+    let server = App::create()
+        .await
+        .expect("Failed to create app")
+        .serve(listener);
+    let _ = tokio::spawn(server);
+
+    Ok(test_app)
+}

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -1,0 +1,21 @@
+use hyper::StatusCode;
+
+mod common;
+
+#[tokio::test]
+async fn health_check_works() {
+    // Arrange
+    let app = common::spawn_app().await.expect("Failed to spawn our app.");
+    let client = reqwest::Client::new();
+
+    // Act
+    let response = client
+        .get(format!("{}/health", app.address()))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(Some(0), response.content_length());
+}


### PR DESCRIPTION
Creates a framework for running integration tests against a running version of the server. Refactors `main.rs` into mostly a thin wrapper than now calls into `lib.rs` for building and serving the application.

## Changelog

- docs: Comment on how to compile without the database around
- refactor: Moved starting code into lib with only a thin wrapper in the `main` for building the binary
- refactor: Tracing directives
- test: Created integration through http against a running server
- build: Upgraded to rust version 1.72.0
